### PR TITLE
Add missing imports

### DIFF
--- a/build/run.py
+++ b/build/run.py
@@ -1,5 +1,8 @@
 import os
 import sys
+from io import BytesIO
+from zipfile import ZipFile
+from urllib.request import urlopen
 
 
 class UIRunningException(Exception):


### PR DESCRIPTION
Rebase removed `build/run.py`imports which are required. This PR fixes this.