### PR TITLE
Use pathlib api to get the filename

### DIFF
--- a/interface.py
+++ b/interface.py
@@ -38,12 +38,12 @@ def status(msg):
 
 
 def download(download_path):
-    name = download_path.split("/")[-1]
+    name = download_path.name
     shutil.rmtree(DFT.DOWNLOADS_PATH)
     os.makedirs(DFT.DOWNLOADS_PATH)
     shutil.copy(download_path, DFT.DOWNLOADS_PATH / name)
     DOWNLOAD.markdown(
-        f"<b>[Click here to download {name}](downloads/{name})</b>", unsafe_allow_html=True
+        f"<a href='downloads/{name}'>Click here to download {name}</a>", unsafe_allow_html=True
     )
 
 


### PR DESCRIPTION
This was generating some errors, specifically on Windows.
I've changed the markdown to use direct link (otherwise it opens a new application window in the Electron application).
